### PR TITLE
[web] Fix Firefox infinite loop by prepending '/' to generated routes

### DIFF
--- a/web/velocity/src/app/Route.elm
+++ b/web/velocity/src/app/Route.elm
@@ -72,7 +72,7 @@ routeToString page =
                 |> String.join "&"
 
         routeString =
-            path
+            "/" ++ path
     in
         if String.length queryString > 0 then
             routeString ++ "?" ++ queryString


### PR DESCRIPTION
This was the `history.replaceState` bug where routing to Home (i.e. empty string '') would go to '/' in Chrome, but stay on the current page in Firefox, which would then loop infinitely.