### PR TITLE
[web] WIP/RFC Sketch out another idea for handling API 401s

### DIFF
--- a/web/velocity/src/app/Page/Home.elm
+++ b/web/velocity/src/app/Page/Home.elm
@@ -12,8 +12,8 @@ import Data.PaginatedList as PaginatedList exposing (Paginated(..))
 import Util exposing ((=>), onClickStopPropagation)
 import Views.Page as Page
 import Task exposing (Task)
-import Http
 import Request.Project
+import Request.Errors
 import Page.Helpers exposing (formatDate, sortByDatetime)
 import Route
 import Page.Project.Route as ProjectRoute
@@ -31,7 +31,7 @@ type alias Model =
     { projects : List Project }
 
 
-init : Session msg -> Task PageLoadError Model
+init : Session msg -> Task (Request.Errors.Error PageLoadError) Model
 init session =
     let
         maybeAuthToken =
@@ -39,13 +39,12 @@ init session =
 
         loadProjects =
             Request.Project.list maybeAuthToken
-                |> Http.toTask
 
-        handleLoadError _ =
+        errorPage =
             pageLoadError Page.Home "Homepage is currently unavailable."
     in
         Task.map (\(Paginated { results }) -> Model results) loadProjects
-            |> Task.mapError handleLoadError
+            |> Task.mapError (Request.Errors.withDefaultError errorPage)
 
 
 

--- a/web/velocity/src/app/Page/Login.elm
+++ b/web/velocity/src/app/Page/Login.elm
@@ -12,9 +12,11 @@ import Validate exposing (..)
 import Data.Session as Session exposing (Session)
 import Http
 import Request.User exposing (storeSession)
+import Request.Errors
 import Util exposing ((=>))
 import Data.User as User exposing (User)
 import Page.Helpers exposing (ifBelowLength, validClasses)
+import Task
 
 
 -- MODEL --
@@ -141,7 +143,7 @@ type Msg
     = SubmitForm
     | SetUsername String
     | SetPassword String
-    | LoginCompleted (Result Http.Error User)
+    | LoginCompleted (Result Request.Errors.HttpError User)
 
 
 type ExternalMsg
@@ -171,7 +173,7 @@ update msg model =
                             , submitting = True
                             , globalError = Nothing
                         }
-                            => Http.send LoginCompleted (Request.User.login submitValues)
+                            => Task.attempt LoginCompleted (Request.User.login submitValues)
                             => NoOp
 
                 errors ->

--- a/web/velocity/src/app/Page/Project/Commit.elm
+++ b/web/velocity/src/app/Page/Project/Commit.elm
@@ -70,17 +70,14 @@ init session project hash maybeRoute =
         loadCommit =
             maybeAuthToken
                 |> Request.Commit.get project.slug hash
-                |> Http.toTask
 
         loadTasks =
             maybeAuthToken
                 |> Request.Commit.tasks project.slug hash
-                |> Http.toTask
 
         loadBuilds =
             maybeAuthToken
                 |> Request.Commit.builds project.slug hash
-                |> Http.toTask
 
         initialModel commit (Paginated tasks) (Paginated builds) =
             { commit = commit
@@ -93,16 +90,14 @@ init session project hash maybeRoute =
             pageLoadError Page.Project "Project unavailable."
     in
         Task.map3 initialModel loadCommit loadTasks loadBuilds
-            |> Task.andThen
+            |> Task.map
                 (\successModel ->
                     case maybeRoute of
                         Just route ->
                             update project session (SetRoute maybeRoute) successModel
-                                |> Task.succeed
 
                         Nothing ->
                             ( successModel, Cmd.none )
-                                |> Task.succeed
                 )
             |> Task.mapError handleLoadError
 

--- a/web/velocity/src/app/Page/Project/Settings.elm
+++ b/web/velocity/src/app/Page/Project/Settings.elm
@@ -9,8 +9,9 @@ import Util exposing ((=>))
 import Route exposing (Route)
 import Page.Project.Route as ProjectRoute
 import Request.Project
-import Http
+import Request.Errors
 import Route
+import Task
 
 
 -- MODEL --
@@ -131,7 +132,7 @@ breadcrumb project =
 
 type Msg
     = SubmitProjectDelete
-    | ProjectDeleted (Result Http.Error ())
+    | ProjectDeleted (Result Request.Errors.HttpError ())
     | SetDeleteState ConfirmDeleteState
 
 
@@ -143,7 +144,7 @@ update project session msg model =
                 cmdFromAuth authToken =
                     authToken
                         |> Request.Project.delete project.slug
-                        |> Http.send ProjectDeleted
+                        |> Task.attempt ProjectDeleted
 
                 cmd =
                     session

--- a/web/velocity/src/app/Request/Build.elm
+++ b/web/velocity/src/app/Request/Build.elm
@@ -6,16 +6,18 @@ import Data.BuildStream as BuildStream exposing (BuildStream, BuildStreamOutput)
 import Data.PaginatedList as PaginatedList exposing (PaginatedList)
 import Data.AuthToken as AuthToken exposing (AuthToken, withAuthorization)
 import Request.Helpers exposing (apiUrl)
+import Request.Errors
 import HttpBuilder exposing (RequestBuilder, withBody, withExpect, withQueryParams)
 import Http
 import Array exposing (Array)
 import Json.Decode as Decode
+import Task exposing (Task)
 
 
 steps :
     Build.Id
     -> Maybe AuthToken
-    -> Http.Request (PaginatedList BuildStep)
+    -> Task Request.Errors.HttpError (PaginatedList BuildStep)
 steps id maybeToken =
     let
         expect =
@@ -27,13 +29,14 @@ steps id maybeToken =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> Task.mapError Request.Errors.handleError
 
 
 streams :
     Maybe AuthToken
     -> BuildStep.Id
-    -> Http.Request (PaginatedList BuildStream)
+    -> Task Request.Errors.HttpError (PaginatedList BuildStream)
 streams maybeToken id =
     let
         expect =
@@ -45,13 +48,14 @@ streams maybeToken id =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> Task.mapError Request.Errors.handleError
 
 
 streamOutput :
     Maybe AuthToken
     -> BuildStream.Id
-    -> Http.Request (Array BuildStreamOutput)
+    -> Task Request.Errors.HttpError (Array BuildStreamOutput)
 streamOutput maybeToken id =
     let
         expect =
@@ -64,4 +68,5 @@ streamOutput maybeToken id =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> Task.mapError Request.Errors.handleError

--- a/web/velocity/src/app/Request/Commit.elm
+++ b/web/velocity/src/app/Request/Commit.elm
@@ -9,9 +9,11 @@ import Data.Build as Build exposing (Build)
 import Data.PaginatedList as PaginatedList exposing (PaginatedList)
 import Json.Encode as Encode
 import Request.Helpers exposing (apiUrl)
+import Request.Errors
 import HttpBuilder exposing (RequestBuilder, withBody, withExpect, withQueryParams)
 import Util exposing ((=>))
 import Http
+import Task as ElmTask
 
 
 baseUrl : String
@@ -29,7 +31,7 @@ list :
     -> Int
     -> Int
     -> Maybe AuthToken
-    -> Http.Request (PaginatedList Commit)
+    -> ElmTask.Task Request.Errors.HttpError (PaginatedList Commit)
 list projectSlug maybeBranch amount page maybeToken =
     let
         expect =
@@ -62,14 +64,15 @@ list projectSlug maybeBranch amount page maybeToken =
             |> HttpBuilder.withExpect expect
             |> HttpBuilder.withQueryParams queryParams
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> ElmTask.mapError Request.Errors.handleError
 
 
 
 -- GET --
 
 
-get : Project.Slug -> Commit.Hash -> Maybe AuthToken -> Http.Request Commit
+get : Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError Commit
 get projectSlug hash maybeToken =
     let
         expect =
@@ -87,14 +90,15 @@ get projectSlug hash maybeToken =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> ElmTask.mapError Request.Errors.handleError
 
 
 
 -- TASKS --
 
 
-tasks : Project.Slug -> Commit.Hash -> Maybe AuthToken -> Http.Request (PaginatedList Task)
+tasks : Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError (PaginatedList Task)
 tasks projectSlug hash maybeToken =
     let
         expect =
@@ -114,10 +118,11 @@ tasks projectSlug hash maybeToken =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> ElmTask.mapError Request.Errors.handleError
 
 
-task : Project.Slug -> Commit.Hash -> Task.Name -> Maybe AuthToken -> Http.Request Task
+task : Project.Slug -> Commit.Hash -> Task.Name -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError Task
 task projectSlug hash name maybeToken =
     let
         expect =
@@ -137,14 +142,15 @@ task projectSlug hash name maybeToken =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> ElmTask.mapError Request.Errors.handleError
 
 
 
 -- BUILDS --
 
 
-builds : Project.Slug -> Commit.Hash -> Maybe AuthToken -> Http.Request (PaginatedList Build)
+builds : Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError (PaginatedList Build)
 builds projectSlug hash maybeToken =
     let
         expect =
@@ -164,10 +170,11 @@ builds projectSlug hash maybeToken =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> ElmTask.mapError Request.Errors.handleError
 
 
-createBuild : Project.Slug -> Commit.Hash -> Task.Name -> List ( String, String ) -> AuthToken -> Http.Request Build
+createBuild : Project.Slug -> Commit.Hash -> Task.Name -> List ( String, String ) -> AuthToken -> ElmTask.Task Request.Errors.HttpError Build
 createBuild projectSlug hash taskName params token =
     let
         expect =
@@ -214,4 +221,5 @@ createBuild projectSlug hash taskName params token =
             |> HttpBuilder.withExpect expect
             |> withAuthorization (Just token)
             |> withBody body
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> ElmTask.mapError Request.Errors.handleError

--- a/web/velocity/src/app/Request/Errors.elm
+++ b/web/velocity/src/app/Request/Errors.elm
@@ -1,0 +1,56 @@
+module Request.Errors
+    exposing
+        ( Error(..)
+        , HttpError
+        , HandledError(..)
+        , handleError
+        , withDefaultError
+        , mapUnhandledError
+        )
+
+import Http
+
+
+type HandledError
+    = Unauthorized
+
+
+type Error unhandled
+    = HandledError HandledError
+    | UnhandledError unhandled
+
+
+type alias HttpError =
+    Error Http.Error
+
+
+handleError : Http.Error -> Error Http.Error
+handleError err =
+    let
+        unhandled =
+            UnhandledError err
+    in
+        case err of
+            Http.BadStatus { status } ->
+                if status.code == 401 then
+                    HandledError Unauthorized
+                else
+                    unhandled
+
+            _ ->
+                unhandled
+
+
+mapUnhandledError : (Http.Error -> defaultError) -> Error Http.Error -> Error defaultError
+mapUnhandledError f err =
+    case err of
+        UnhandledError httpError ->
+            UnhandledError (f httpError)
+
+        HandledError handled ->
+            HandledError handled
+
+
+withDefaultError : defaultError -> Error Http.Error -> Error defaultError
+withDefaultError defaultError =
+    mapUnhandledError (always defaultError)

--- a/web/velocity/src/app/Request/KnownHost.elm
+++ b/web/velocity/src/app/Request/KnownHost.elm
@@ -4,10 +4,12 @@ import Data.AuthToken as AuthToken exposing (AuthToken, withAuthorization)
 import Data.KnownHost as KnownHost exposing (KnownHost)
 import Json.Encode as Encode
 import Request.Helpers exposing (apiUrl)
+import Request.Errors
 import HttpBuilder exposing (RequestBuilder, withBody, withExpect, withQueryParams)
 import Util exposing ((=>))
 import Http
 import Data.PaginatedList as PaginatedList exposing (PaginatedList)
+import Task exposing (Task)
 
 
 baseUrl : String
@@ -19,7 +21,7 @@ baseUrl =
 -- LIST --
 
 
-list : Maybe AuthToken -> Http.Request (PaginatedList KnownHost)
+list : Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList KnownHost)
 list maybeToken =
     let
         expect =
@@ -31,7 +33,8 @@ list maybeToken =
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> Task.mapError Request.Errors.handleError
 
 
 
@@ -44,7 +47,7 @@ type alias CreateConfig record =
     }
 
 
-create : CreateConfig record -> AuthToken -> Http.Request KnownHost
+create : CreateConfig record -> AuthToken -> Task Request.Errors.HttpError KnownHost
 create config token =
     let
         expect =
@@ -64,4 +67,5 @@ create config token =
             |> withAuthorization (Just token)
             |> withBody body
             |> withExpect expect
-            |> HttpBuilder.toRequest
+            |> HttpBuilder.toTask
+            |> Task.mapError Request.Errors.handleError

--- a/web/velocity/src/app/Request/User.elm
+++ b/web/velocity/src/app/Request/User.elm
@@ -5,7 +5,9 @@ import Http
 import Json.Encode as Encode
 import Ports
 import Request.Helpers exposing (apiUrl)
+import Request.Errors
 import Util exposing ((=>))
+import Task exposing (Task)
 
 
 storeSession : User -> Cmd msg
@@ -16,7 +18,7 @@ storeSession user =
         |> Ports.storeSession
 
 
-login : { r | username : String, password : String } -> Http.Request User
+login : { r | username : String, password : String } -> Task Request.Errors.HttpError User
 login { username, password } =
     let
         user =
@@ -30,3 +32,5 @@ login { username, password } =
     in
         User.decoder
             |> Http.post (apiUrl "/auth") body
+            |> Http.toTask
+            |> Task.mapError Request.Errors.handleError


### PR DESCRIPTION
Do not merge.

Another experiment - this one includes a wrapper type around the request errors, making the difference between `HandledError` and `UnhandledError` more explicit.

I’ve only implemented it for one request, the `Request.Project.list` one, to see whether it could work (that’s why there’s a second `transition` function at the moment).

It changes the signature of the `Request.Project.list` function to return the request `Task` rather than the `Request` itself, so that it can include the failure handling.

I’ve also played around with using a generic `LoadFailed` msg to display error content rather than the `ProjectsLoaded (Ok …)` and `ProjectsLoaded (Err …)` approach, which has duplicated error handling for each page.

Just experimenting anyway - the previous PR included a bit of dodgy `Result.Err` unpacking which this avoids, but it still might not be the right answer :)
