### PR TITLE
Add Context module for dynamic URLs, including ws:// vs wss:// switching

### DIFF
--- a/web/velocity/src/app/Context.elm
+++ b/web/velocity/src/app/Context.elm
@@ -1,0 +1,34 @@
+module Context exposing (Context, initContext)
+
+import Navigation exposing (Location)
+
+
+type alias Context =
+    { apiUrlBase : String
+    , wsUrl : String
+    }
+
+
+initContext : Location -> Context
+initContext { protocol, hostname } =
+    -- Reminder: location.host includes port if there is one;
+    -- location.hostname does not.
+    let
+        isSecureProtocol =
+            protocol == "https:"
+
+        -- API host is currently web hostname + default port
+        apiHost =
+            hostname
+
+        wsProtocol =
+            if isSecureProtocol then
+                "wss:"
+            else
+                "ws:"
+    in
+        { apiUrlBase =
+            protocol ++ "//" ++ apiHost ++ "/v1"
+        , wsUrl =
+            wsProtocol ++ "//" ++ apiHost ++ "/v1/ws"
+        }

--- a/web/velocity/src/app/Page/Home.elm
+++ b/web/velocity/src/app/Page/Home.elm
@@ -3,6 +3,7 @@ module Page.Home exposing (view, update, Model, Msg, init, channelName, events)
 {-| The homepage. You can get here via either the / or /#/ routes.
 -}
 
+import Context exposing (Context)
 import Html exposing (..)
 import Html.Attributes exposing (class, href, id, placeholder, attribute, classList, style)
 import Data.Session as Session exposing (Session)
@@ -31,14 +32,14 @@ type alias Model =
     { projects : List Project }
 
 
-init : Session msg -> Task (Request.Errors.Error PageLoadError) Model
-init session =
+init : Context -> Session msg -> Task (Request.Errors.Error PageLoadError) Model
+init context session =
     let
         maybeAuthToken =
             Maybe.map .token session.user
 
         loadProjects =
-            Request.Project.list maybeAuthToken
+            Request.Project.list context maybeAuthToken
 
         errorPage =
             pageLoadError Page.Home "Homepage is currently unavailable."

--- a/web/velocity/src/app/Page/KnownHosts.elm
+++ b/web/velocity/src/app/Page/KnownHosts.elm
@@ -1,5 +1,6 @@
 module Page.KnownHosts exposing (..)
 
+import Context exposing (Context)
 import Data.KnownHost as KnownHost exposing (KnownHost)
 import Data.Session as Session exposing (Session)
 import Data.PaginatedList as PaginatedList exposing (Paginated(..))
@@ -61,14 +62,14 @@ initialForm =
     }
 
 
-init : Session msg -> Task (Request.Errors.Error PageLoadError) Model
-init session =
+init : Context -> Session msg -> Task (Request.Errors.Error PageLoadError) Model
+init context session =
     let
         maybeAuthToken =
             Maybe.map .token session.user
 
         loadKnownHosts =
-            Request.KnownHost.list maybeAuthToken
+            Request.KnownHost.list context maybeAuthToken
 
         loadError =
             pageLoadError Page.KnownHosts "Known hosts are currently unavailable."
@@ -257,8 +258,8 @@ serverErrorToFormError ( fieldNameString, errorString ) =
         field => errorString
 
 
-update : Session msg -> Msg -> Model -> ( ( Model, Cmd Msg ), ExternalMsg )
-update session msg model =
+update : Context -> Session msg -> Msg -> Model -> ( ( Model, Cmd Msg ), ExternalMsg )
+update context session msg model =
     let
         form =
             model.form
@@ -277,7 +278,7 @@ update session msg model =
 
                             cmdFromAuth authToken =
                                 authToken
-                                    |> Request.KnownHost.create submitValues
+                                    |> Request.KnownHost.create context submitValues
                                     |> Task.attempt KnownHostCreated
 
                             cmd =

--- a/web/velocity/src/app/Page/Login.elm
+++ b/web/velocity/src/app/Page/Login.elm
@@ -3,6 +3,7 @@ module Page.Login exposing (view, update, Model, Msg, initialModel, ExternalMsg(
 {-| The login page.
 -}
 
+import Context exposing (Context)
 import Route exposing (Route)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -10,7 +11,6 @@ import Html.Events exposing (..)
 import Views.Form as Form
 import Validate exposing (..)
 import Data.Session as Session exposing (Session)
-import Http
 import Request.User exposing (storeSession)
 import Request.Errors
 import Util exposing ((=>))
@@ -156,8 +156,8 @@ updateInput field value =
     FormField value True field
 
 
-update : Msg -> Model -> ( ( Model, Cmd Msg ), ExternalMsg )
-update msg model =
+update : Context -> Msg -> Model -> ( ( Model, Cmd Msg ), ExternalMsg )
+update context msg model =
     case msg of
         SubmitForm ->
             case validate model of
@@ -173,7 +173,7 @@ update msg model =
                             , submitting = True
                             , globalError = Nothing
                         }
-                            => Task.attempt LoginCompleted (Request.User.login submitValues)
+                            => Task.attempt LoginCompleted (Request.User.login context submitValues)
                             => NoOp
 
                 errors ->

--- a/web/velocity/src/app/Page/Project.elm
+++ b/web/velocity/src/app/Page/Project.elm
@@ -1,5 +1,6 @@
 module Page.Project exposing (..)
 
+import Context exposing (Context)
 import Page.Errored as Errored exposing (PageLoadError, pageLoadError)
 import Request.Project
 import Request.Errors
@@ -63,20 +64,20 @@ initialSubPage =
     Blank
 
 
-init : Session msg -> Project.Slug -> Maybe ProjectRoute.Route -> Task (Request.Errors.Error PageLoadError) ( Model, Cmd Msg )
-init session slug maybeRoute =
+init : Context -> Session msg -> Project.Slug -> Maybe ProjectRoute.Route -> Task (Request.Errors.Error PageLoadError) ( Model, Cmd Msg )
+init context session slug maybeRoute =
     let
         maybeAuthToken =
             Maybe.map .token session.user
 
         loadProject =
-            Request.Project.get slug maybeAuthToken
+            Request.Project.get context slug maybeAuthToken
 
         loadBranches =
-            Request.Project.branches slug maybeAuthToken
+            Request.Project.branches context slug maybeAuthToken
 
         loadBuilds =
-            Request.Project.builds slug maybeAuthToken
+            Request.Project.builds context slug maybeAuthToken
 
         initialModel project (Paginated branches) (Paginated builds) =
             { project = project
@@ -98,7 +99,7 @@ init session slug maybeRoute =
                 (\successModel ->
                     case maybeRoute of
                         Just route ->
-                            update session (SetRoute maybeRoute) successModel
+                            update context session (SetRoute maybeRoute) successModel
 
                         Nothing ->
                             ( successModel, Cmd.none )
@@ -434,8 +435,8 @@ getSubPage subPageState =
             subPage
 
 
-setRoute : Session msg -> Maybe ProjectRoute.Route -> Model -> ( Model, Cmd Msg )
-setRoute session maybeRoute model =
+setRoute : Context -> Session msg -> Maybe ProjectRoute.Route -> Model -> ( Model, Cmd Msg )
+setRoute context session maybeRoute model =
     let
         transition toMsg task =
             { model | subPageState = TransitioningFrom (getSubPage model.subPageState) }
@@ -459,7 +460,7 @@ setRoute session maybeRoute model =
             Just (ProjectRoute.Commits maybeBranch maybePage) ->
                 case session.user of
                     Just user ->
-                        Commits.init session model.branches model.project.slug maybeBranch maybePage
+                        Commits.init context session model.branches model.project.slug maybeBranch maybePage
                             |> transition CommitsLoaded
 
                     Nothing ->
@@ -469,14 +470,14 @@ setRoute session maybeRoute model =
                 let
                     loadFreshPage =
                         Just maybeRoute
-                            |> Commit.init session model.project hash
+                            |> Commit.init context session model.project hash
                             |> transition CommitLoaded
 
                     transitionSubPage subModel =
                         let
                             ( newModel, newMsg ) =
                                 subModel
-                                    |> Commit.update model.project session (Commit.SetRoute (Just maybeRoute))
+                                    |> Commit.update context model.project session (Commit.SetRoute (Just maybeRoute))
                         in
                             { model | subPageState = Loaded (Commit newModel) }
                                 => Cmd.map CommitMsg newMsg
@@ -519,13 +520,13 @@ pageErrored model activePage errorMessage =
         { model | subPageState = Loaded (Errored error) } => Cmd.none
 
 
-update : Session msg -> Msg -> Model -> ( Model, Cmd Msg )
-update session msg model =
-    updateSubPage session (getSubPage model.subPageState) msg model
+update : Context -> Session msg -> Msg -> Model -> ( Model, Cmd Msg )
+update context session msg model =
+    updateSubPage context session (getSubPage model.subPageState) msg model
 
 
-updateSubPage : Session msg -> SubPage -> Msg -> Model -> ( Model, Cmd Msg )
-updateSubPage session subPage msg model =
+updateSubPage : Context -> Session msg -> SubPage -> Msg -> Model -> ( Model, Cmd Msg )
+updateSubPage context session subPage msg model =
     let
         toPage toModel toMsg subUpdate subMsg subModel =
             let
@@ -543,10 +544,10 @@ updateSubPage session subPage msg model =
                     => newUrl url
 
             ( SetRoute route, _ ) ->
-                setRoute session route model
+                setRoute context session route model
 
             ( SettingsMsg subMsg, Settings subModel ) ->
-                toPage Settings SettingsMsg (Settings.update model.project session) subMsg subModel
+                toPage Settings SettingsMsg (Settings.update context model.project session) subMsg subModel
 
             ( CommitsLoaded (Ok subModel), _ ) ->
                 { model | subPageState = Loaded (Commits subModel) }
@@ -557,7 +558,7 @@ updateSubPage session subPage msg model =
                     => Cmd.none
 
             ( CommitsMsg subMsg, Commits subModel ) ->
-                toPage Commits CommitsMsg (Commits.update model.project session) subMsg subModel
+                toPage Commits CommitsMsg (Commits.update context model.project session) subMsg subModel
 
             ( OverviewMsg subMsg, Overview subModel ) ->
                 toPage Overview OverviewMsg (Overview.update model.project session) subMsg subModel
@@ -573,7 +574,7 @@ updateSubPage session subPage msg model =
             ( CommitMsg subMsg, Commit subModel ) ->
                 let
                     ( newSubModel, newCmd ) =
-                        Commit.update model.project session subMsg subModel
+                        Commit.update context model.project session subMsg subModel
                 in
                     { model | subPageState = Loaded (Commit newSubModel) }
                         ! [ Cmd.map CommitMsg newCmd ]
@@ -602,7 +603,7 @@ updateSubPage session subPage msg model =
 
             ( RefreshBranches _, _ ) ->
                 model
-                    => Task.attempt RefreshBranchesComplete (Request.Project.branches model.project.slug (Maybe.map .token session.user))
+                    => Task.attempt RefreshBranchesComplete (Request.Project.branches context model.project.slug (Maybe.map .token session.user))
 
             ( RefreshBranchesComplete (Ok (Paginated { results })), _ ) ->
                 { model | branches = results }

--- a/web/velocity/src/app/Page/Project/Settings.elm
+++ b/web/velocity/src/app/Page/Project/Settings.elm
@@ -1,5 +1,6 @@
 module Page.Project.Settings exposing (..)
 
+import Context exposing (Context)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
@@ -136,14 +137,14 @@ type Msg
     | SetDeleteState ConfirmDeleteState
 
 
-update : Project -> Session msg -> Msg -> Model -> ( Model, Cmd Msg )
-update project session msg model =
+update : Context -> Project -> Session msg -> Msg -> Model -> ( Model, Cmd Msg )
+update context project session msg model =
     case msg of
         SubmitProjectDelete ->
             let
                 cmdFromAuth authToken =
                     authToken
-                        |> Request.Project.delete project.slug
+                        |> Request.Project.delete context project.slug
                         |> Task.attempt ProjectDeleted
 
                 cmd =

--- a/web/velocity/src/app/Page/Projects.elm
+++ b/web/velocity/src/app/Page/Projects.elm
@@ -1,5 +1,6 @@
 module Page.Projects exposing (..)
 
+import Context exposing (Context)
 import Data.Project as Project exposing (Project)
 import Data.Session as Session exposing (Session)
 import Task exposing (Task)
@@ -72,14 +73,14 @@ initialForm =
     }
 
 
-init : Session msg -> Task (Request.Errors.Error PageLoadError) Model
-init session =
+init : Context -> Session msg -> Task (Request.Errors.Error PageLoadError) Model
+init context session =
     let
         maybeAuthToken =
             Maybe.map .token session.user
 
         loadProjects =
-            Request.Project.list maybeAuthToken
+            Request.Project.list context maybeAuthToken
 
         errorPage =
             pageLoadError Page.Projects "Projects are currently unavailable."
@@ -365,8 +366,8 @@ serverErrorToFormError ( fieldNameString, errorString ) =
         field => errorString
 
 
-update : Session msg -> Msg -> Model -> ( ( Model, Cmd Msg ), ExternalMsg )
-update session msg model =
+update : Context -> Session msg -> Msg -> Model -> ( ( Model, Cmd Msg ), ExternalMsg )
+update context session msg model =
     let
         form =
             model.form
@@ -396,7 +397,7 @@ update session msg model =
 
                             cmdFromAuth authToken =
                                 authToken
-                                    |> Request.Project.create submitValues
+                                    |> Request.Project.create context submitValues
                                     |> Task.attempt ProjectCreated
 
                             cmd =

--- a/web/velocity/src/app/Request/Build.elm
+++ b/web/velocity/src/app/Request/Build.elm
@@ -1,5 +1,6 @@
 module Request.Build exposing (..)
 
+import Context exposing (Context)
 import Data.Build as Build exposing (Build)
 import Data.BuildStep as BuildStep exposing (BuildStep)
 import Data.BuildStream as BuildStream exposing (BuildStream, BuildStreamOutput)
@@ -15,17 +16,18 @@ import Task exposing (Task)
 
 
 steps :
-    Build.Id
+    Context
+    -> Build.Id
     -> Maybe AuthToken
     -> Task Request.Errors.HttpError (PaginatedList BuildStep)
-steps id maybeToken =
+steps context id maybeToken =
     let
         expect =
             BuildStep.decoder
                 |> PaginatedList.decoder
                 |> Http.expectJson
     in
-        apiUrl ("/builds" ++ "/" ++ Build.idToString id ++ "/steps")
+        apiUrl context ("/builds" ++ "/" ++ Build.idToString id ++ "/steps")
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -34,17 +36,18 @@ steps id maybeToken =
 
 
 streams :
-    Maybe AuthToken
+    Context
+    -> Maybe AuthToken
     -> BuildStep.Id
     -> Task Request.Errors.HttpError (PaginatedList BuildStream)
-streams maybeToken id =
+streams context maybeToken id =
     let
         expect =
             BuildStream.decoder
                 |> PaginatedList.decoder
                 |> Http.expectJson
     in
-        apiUrl ("/steps" ++ "/" ++ BuildStep.idToString id ++ "/streams")
+        apiUrl context ("/steps" ++ "/" ++ BuildStep.idToString id ++ "/streams")
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -53,10 +56,11 @@ streams maybeToken id =
 
 
 streamOutput :
-    Maybe AuthToken
+    Context
+    -> Maybe AuthToken
     -> BuildStream.Id
     -> Task Request.Errors.HttpError (Array BuildStreamOutput)
-streamOutput maybeToken id =
+streamOutput context maybeToken id =
     let
         expect =
             BuildStream.outputDecoder
@@ -64,7 +68,7 @@ streamOutput maybeToken id =
                 |> Decode.at [ "data" ]
                 |> Http.expectJson
     in
-        apiUrl ("/streams/" ++ BuildStream.idToString id ++ "/log")
+        apiUrl context ("/streams/" ++ BuildStream.idToString id ++ "/log")
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken

--- a/web/velocity/src/app/Request/Commit.elm
+++ b/web/velocity/src/app/Request/Commit.elm
@@ -1,5 +1,6 @@
 module Request.Commit exposing (list, get, tasks, task, builds, createBuild)
 
+import Context exposing (Context)
 import Data.AuthToken as AuthToken exposing (AuthToken, withAuthorization)
 import Data.Project as Project exposing (Project)
 import Data.Commit as Commit exposing (Commit)
@@ -26,13 +27,14 @@ baseUrl =
 
 
 list :
-    Project.Slug
+    Context
+    -> Project.Slug
     -> Maybe Branch.Name
     -> Int
     -> Int
     -> Maybe AuthToken
     -> ElmTask.Task Request.Errors.HttpError (PaginatedList Commit)
-list projectSlug maybeBranch amount page maybeToken =
+list context projectSlug maybeBranch amount page maybeToken =
     let
         expect =
             Commit.decoder
@@ -59,7 +61,7 @@ list projectSlug maybeBranch amount page maybeToken =
                 |> amountParam
                 |> pageParam
     in
-        apiUrl (baseUrl ++ "/" ++ Project.slugToString projectSlug ++ "/commits")
+        apiUrl context (baseUrl ++ "/" ++ Project.slugToString projectSlug ++ "/commits")
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> HttpBuilder.withQueryParams queryParams
@@ -72,8 +74,8 @@ list projectSlug maybeBranch amount page maybeToken =
 -- GET --
 
 
-get : Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError Commit
-get projectSlug hash maybeToken =
+get : Context -> Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError Commit
+get context projectSlug hash maybeToken =
     let
         expect =
             Commit.decoder
@@ -86,7 +88,7 @@ get projectSlug hash maybeToken =
             , Commit.hashToString hash
             ]
     in
-        apiUrl (String.join "/" urlPieces)
+        apiUrl context (String.join "/" urlPieces)
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -98,8 +100,8 @@ get projectSlug hash maybeToken =
 -- TASKS --
 
 
-tasks : Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError (PaginatedList Task)
-tasks projectSlug hash maybeToken =
+tasks : Context -> Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError (PaginatedList Task)
+tasks context projectSlug hash maybeToken =
     let
         expect =
             Task.decoder
@@ -114,7 +116,7 @@ tasks projectSlug hash maybeToken =
             , "tasks"
             ]
     in
-        apiUrl (String.join "/" urlPieces)
+        apiUrl context (String.join "/" urlPieces)
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -122,8 +124,8 @@ tasks projectSlug hash maybeToken =
             |> ElmTask.mapError Request.Errors.handleError
 
 
-task : Project.Slug -> Commit.Hash -> Task.Name -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError Task
-task projectSlug hash name maybeToken =
+task : Context -> Project.Slug -> Commit.Hash -> Task.Name -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError Task
+task context projectSlug hash name maybeToken =
     let
         expect =
             Task.decoder
@@ -138,7 +140,7 @@ task projectSlug hash name maybeToken =
             , Task.nameToString name
             ]
     in
-        apiUrl (String.join "/" urlPieces)
+        apiUrl context (String.join "/" urlPieces)
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -150,8 +152,8 @@ task projectSlug hash name maybeToken =
 -- BUILDS --
 
 
-builds : Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError (PaginatedList Build)
-builds projectSlug hash maybeToken =
+builds : Context -> Project.Slug -> Commit.Hash -> Maybe AuthToken -> ElmTask.Task Request.Errors.HttpError (PaginatedList Build)
+builds context projectSlug hash maybeToken =
     let
         expect =
             Build.decoder
@@ -166,7 +168,7 @@ builds projectSlug hash maybeToken =
             , "builds"
             ]
     in
-        apiUrl (String.join "/" urlPieces)
+        apiUrl context (String.join "/" urlPieces)
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -174,8 +176,8 @@ builds projectSlug hash maybeToken =
             |> ElmTask.mapError Request.Errors.handleError
 
 
-createBuild : Project.Slug -> Commit.Hash -> Task.Name -> List ( String, String ) -> AuthToken -> ElmTask.Task Request.Errors.HttpError Build
-createBuild projectSlug hash taskName params token =
+createBuild : Context -> Project.Slug -> Commit.Hash -> Task.Name -> List ( String, String ) -> AuthToken -> ElmTask.Task Request.Errors.HttpError Build
+createBuild context projectSlug hash taskName params token =
     let
         expect =
             Build.decoder
@@ -216,7 +218,7 @@ createBuild projectSlug hash taskName params token =
             encodedBody
                 |> Http.jsonBody
     in
-        apiUrl (String.join "/" urlPieces)
+        apiUrl context (String.join "/" urlPieces)
             |> HttpBuilder.post
             |> HttpBuilder.withExpect expect
             |> withAuthorization (Just token)

--- a/web/velocity/src/app/Request/Helpers.elm
+++ b/web/velocity/src/app/Request/Helpers.elm
@@ -1,9 +1,6 @@
 module Request.Helpers exposing (apiUrl)
 
-import HttpBuilder
-import Http
 
-
-apiUrl : String -> String
-apiUrl str =
-    "http://localhost/v1" ++ str
+apiUrl : { r | apiUrlBase : String } -> String -> String
+apiUrl { apiUrlBase } str =
+    apiUrlBase ++ str

--- a/web/velocity/src/app/Request/KnownHost.elm
+++ b/web/velocity/src/app/Request/KnownHost.elm
@@ -1,5 +1,6 @@
 module Request.KnownHost exposing (list, create)
 
+import Context exposing (Context)
 import Data.AuthToken as AuthToken exposing (AuthToken, withAuthorization)
 import Data.KnownHost as KnownHost exposing (KnownHost)
 import Json.Encode as Encode
@@ -21,15 +22,15 @@ baseUrl =
 -- LIST --
 
 
-list : Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList KnownHost)
-list maybeToken =
+list : Context -> Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList KnownHost)
+list context maybeToken =
     let
         expect =
             KnownHost.decoder
                 |> PaginatedList.decoder
                 |> Http.expectJson
     in
-        apiUrl baseUrl
+        apiUrl context baseUrl
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -47,8 +48,8 @@ type alias CreateConfig record =
     }
 
 
-create : CreateConfig record -> AuthToken -> Task Request.Errors.HttpError KnownHost
-create config token =
+create : Context -> CreateConfig record -> AuthToken -> Task Request.Errors.HttpError KnownHost
+create context config token =
     let
         expect =
             KnownHost.decoder
@@ -62,7 +63,7 @@ create config token =
             project
                 |> Http.jsonBody
     in
-        apiUrl baseUrl
+        apiUrl context baseUrl
             |> HttpBuilder.post
             |> withAuthorization (Just token)
             |> withBody body

--- a/web/velocity/src/app/Request/Project.elm
+++ b/web/velocity/src/app/Request/Project.elm
@@ -9,6 +9,7 @@ module Request.Project
         , builds
         )
 
+import Context exposing (Context)
 import Data.AuthToken as AuthToken exposing (AuthToken, withAuthorization)
 import Data.Project as Project exposing (Project)
 import Data.Branch as Branch exposing (Branch)
@@ -32,15 +33,15 @@ baseUrl =
 -- LIST --
 
 
-list : Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList Project)
-list maybeToken =
+list : Context -> Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList Project)
+list context maybeToken =
     let
         expect =
             Project.decoder
                 |> PaginatedList.decoder
                 |> Http.expectJson
     in
-        apiUrl baseUrl
+        apiUrl context baseUrl
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -52,14 +53,14 @@ list maybeToken =
 -- SYNC --
 
 
-sync : Project.Slug -> AuthToken -> Task Request.Errors.HttpError Project
-sync slug token =
+sync : Context -> Project.Slug -> AuthToken -> Task Request.Errors.HttpError Project
+sync context slug token =
     let
         expect =
             Project.decoder
                 |> Http.expectJson
     in
-        apiUrl (baseUrl ++ "/" ++ Project.slugToString slug ++ "/sync")
+        apiUrl context (baseUrl ++ "/" ++ Project.slugToString slug ++ "/sync")
             |> HttpBuilder.post
             |> withAuthorization (Just token)
             |> withExpect expect
@@ -71,15 +72,15 @@ sync slug token =
 -- BRANCHES --
 
 
-branches : Project.Slug -> Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList Branch)
-branches slug maybeToken =
+branches : Context -> Project.Slug -> Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList Branch)
+branches context slug maybeToken =
     let
         expect =
             Branch.decoder
                 |> PaginatedList.decoder
                 |> Http.expectJson
     in
-        apiUrl (baseUrl ++ "/" ++ Project.slugToString slug ++ "/branches")
+        apiUrl context (baseUrl ++ "/" ++ Project.slugToString slug ++ "/branches")
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -91,15 +92,15 @@ branches slug maybeToken =
 -- BUILDS --
 
 
-builds : Project.Slug -> Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList Build)
-builds slug maybeToken =
+builds : Context -> Project.Slug -> Maybe AuthToken -> Task Request.Errors.HttpError (PaginatedList Build)
+builds context slug maybeToken =
     let
         expect =
             Build.decoder
                 |> PaginatedList.decoder
                 |> Http.expectJson
     in
-        apiUrl (baseUrl ++ "/" ++ Project.slugToString slug ++ "/builds")
+        apiUrl context (baseUrl ++ "/" ++ Project.slugToString slug ++ "/builds")
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -111,14 +112,14 @@ builds slug maybeToken =
 -- GET --
 
 
-get : Project.Slug -> Maybe AuthToken -> Task Request.Errors.HttpError Project
-get slug maybeToken =
+get : Context -> Project.Slug -> Maybe AuthToken -> Task Request.Errors.HttpError Project
+get context slug maybeToken =
     let
         expect =
             Project.decoder
                 |> Http.expectJson
     in
-        apiUrl (baseUrl ++ "/" ++ Project.slugToString slug)
+        apiUrl context (baseUrl ++ "/" ++ Project.slugToString slug)
             |> HttpBuilder.get
             |> HttpBuilder.withExpect expect
             |> withAuthorization maybeToken
@@ -138,8 +139,8 @@ type alias CreateConfig record =
     }
 
 
-create : CreateConfig record -> AuthToken -> Task Request.Errors.HttpError Project
-create config token =
+create : Context -> CreateConfig record -> AuthToken -> Task Request.Errors.HttpError Project
+create context config token =
     let
         expect =
             Project.decoder
@@ -160,7 +161,7 @@ create config token =
                 |> Encode.object
                 |> Http.jsonBody
     in
-        apiUrl baseUrl
+        apiUrl context baseUrl
             |> HttpBuilder.post
             |> withAuthorization (Just token)
             |> withBody body
@@ -173,9 +174,9 @@ create config token =
 -- DELETE --
 
 
-delete : Project.Slug -> AuthToken -> Task Request.Errors.HttpError ()
-delete slug token =
-    apiUrl (baseUrl ++ "/" ++ Project.slugToString slug)
+delete : Context -> Project.Slug -> AuthToken -> Task Request.Errors.HttpError ()
+delete context slug token =
+    apiUrl context (baseUrl ++ "/" ++ Project.slugToString slug)
         |> HttpBuilder.delete
         |> withAuthorization (Just token)
         |> withExpect (Http.expectStringResponse (\_ -> Ok ()))

--- a/web/velocity/src/app/Request/User.elm
+++ b/web/velocity/src/app/Request/User.elm
@@ -1,5 +1,6 @@
 module Request.User exposing (login, storeSession)
 
+import Context exposing (Context)
 import Data.User as User exposing (User)
 import Http
 import Json.Encode as Encode
@@ -18,8 +19,8 @@ storeSession user =
         |> Ports.storeSession
 
 
-login : { r | username : String, password : String } -> Task Request.Errors.HttpError User
-login { username, password } =
+login : Context -> { r | username : String, password : String } -> Task Request.Errors.HttpError User
+login context { username, password } =
     let
         user =
             Encode.object
@@ -31,6 +32,6 @@ login { username, password } =
             user |> Http.jsonBody
     in
         User.decoder
-            |> Http.post (apiUrl "/auth") body
+            |> Http.post (apiUrl context "/auth") body
             |> Http.toTask
             |> Task.mapError Request.Errors.handleError


### PR DESCRIPTION
Added a `Context` bag-o-stuff, containing the api and websocket urls, which are calculated based on the current location. This context is then passed around to all the functions that need it to build urls.

I can’t think of a better way to do this - and I can think of other ways this will be useful in the future (e.g. theming, localisation, other environment stuff) - but let me know if this is really dumb…