### PR TITLE
[backend] Exposed key that signed commit

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
 
   architect:
     image: golang:1.10
-    command: /bin/sh -c "eval `ssh-agent` && go run cmd/vci-architect/main.go"
+    command: /bin/sh -c "eval `ssh-agent` && exec go run cmd/vci-architect/main.go"
     working_dir: /go/src/github.com/velocity-ci/velocity/backend/
     environment:
       # LOG_LEVEL: debug
@@ -28,7 +28,7 @@ services:
 
   builder:
     image: golang:1.10
-    command: /bin/sh -c "eval `ssh-agent` && go run cmd/vci-builder/main.go"
+    command: /bin/sh -c "eval `ssh-agent` && exec go run cmd/vci-builder/main.go"
     working_dir: /go/src/github.com/velocity-ci/velocity/backend/
     environment:
       LOG_LEVEL: debug

--- a/backend/pkg/architect/rest/commits.go
+++ b/backend/pkg/architect/rest/commits.go
@@ -17,6 +17,7 @@ type commitResponse struct {
 	Author    string    `json:"author"`
 	CreatedAt time.Time `json:"createdAt"`
 	Message   string    `json:"message"`
+	Signed    string    `json:"signed"`
 	Branches  []string  `json:"branches"`
 }
 
@@ -36,6 +37,7 @@ func newCommitResponse(c *githistory.Commit, bs []*githistory.Branch) *commitRes
 		Author:    c.Author,
 		CreatedAt: c.CreatedAt,
 		Message:   c.Message,
+		Signed:    c.Signed,
 		Branches:  branches,
 	}
 }

--- a/backend/pkg/domain/build/build_test.go
+++ b/backend/pkg/domain/build/build_test.go
@@ -84,7 +84,7 @@ func (s *BuildSuite) TestNewBuild() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",
@@ -111,7 +111,7 @@ func (s *BuildSuite) TestUpdateBuild() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",
@@ -132,7 +132,7 @@ func (s *BuildSuite) TestGetBuildsForProject() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",
@@ -157,7 +157,7 @@ func (s *BuildSuite) TestGetBuildsForCommit() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",
@@ -182,7 +182,7 @@ func (s *BuildSuite) TestGetBuildsForTask() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",
@@ -207,7 +207,7 @@ func (s *BuildSuite) TestGetRunningBuilds() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",
@@ -234,7 +234,7 @@ func (s *BuildSuite) TestGetWaitingBuilds() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",
@@ -259,7 +259,7 @@ func (s *BuildSuite) TestGetBuildByID() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",

--- a/backend/pkg/domain/build/step_test.go
+++ b/backend/pkg/domain/build/step_test.go
@@ -85,7 +85,7 @@ func (s *StepSuite) TestUpdate() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",

--- a/backend/pkg/domain/build/stream_test.go
+++ b/backend/pkg/domain/build/stream_test.go
@@ -85,7 +85,7 @@ func (s *StreamSuite) TestFileStreamLine() {
 	})
 
 	br := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	tsk := s.taskManager.Create(c, &velocity.Task{
 		Name: "testTask",

--- a/backend/pkg/domain/githistory/branch_test.go
+++ b/backend/pkg/domain/githistory/branch_test.go
@@ -130,7 +130,7 @@ func (s *BranchSuite) TestGetAllForCommit() {
 	b1 := m.Create(p, "testBranch")
 	b2 := m.Create(p, "2estBranch")
 
-	c := s.commitManager.Create(b1, p, "abcdef", "test commit", "me@velocityci.io", time.Now())
+	c := s.commitManager.Create(b1, p, "abcdef", "test commit", "me@velocityci.io", time.Now(), "")
 	s.commitManager.AddCommitToBranch(c, b2)
 
 	bs, total := m.GetAllForCommit(c, &domain.PagingQuery{Limit: 5, Page: 1})

--- a/backend/pkg/domain/githistory/commit-manager.go
+++ b/backend/pkg/domain/githistory/commit-manager.go
@@ -41,6 +41,7 @@ func (m *CommitManager) Create(
 	message string,
 	author string,
 	date time.Time,
+	signed string,
 ) *Commit {
 	c := &Commit{
 		ID:        uuid.NewV3(uuid.NewV1(), p.ID).String(),
@@ -48,6 +49,7 @@ func (m *CommitManager) Create(
 		Hash:      hash,
 		Message:   message,
 		Author:    author,
+		Signed:    signed,
 		CreatedAt: date.UTC(),
 	}
 	m.db.saveCommitToBranch(c, b)

--- a/backend/pkg/domain/githistory/commit-storm.go
+++ b/backend/pkg/domain/githistory/commit-storm.go
@@ -17,6 +17,7 @@ type StormCommit struct {
 	Author    string
 	CreatedAt time.Time
 	Message   string
+	Signed    string
 }
 
 func (s *StormCommit) ToCommit(db *storm.DB) *Commit {
@@ -31,6 +32,7 @@ func (s *StormCommit) ToCommit(db *storm.DB) *Commit {
 		Author:    s.Author,
 		CreatedAt: s.CreatedAt,
 		Message:   s.Message,
+		Signed:    s.Signed,
 	}
 }
 
@@ -42,6 +44,7 @@ func (c *Commit) ToStormCommit() *StormCommit {
 		Author:    c.Author,
 		CreatedAt: c.CreatedAt,
 		Message:   c.Message,
+		Signed:    c.Signed,
 	}
 }
 

--- a/backend/pkg/domain/githistory/commit_test.go
+++ b/backend/pkg/domain/githistory/commit_test.go
@@ -66,7 +66,7 @@ func (s *CommitSuite) TestNew() {
 	b := s.branchManager.Create(p, "testBranch")
 
 	ts := time.Now().UTC()
-	c := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", ts)
+	c := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", ts, "")
 
 	s.NotNil(c)
 
@@ -87,7 +87,7 @@ func (s *CommitSuite) TestGetByProjectAndHash() {
 	b := s.branchManager.Create(p, "testBranch")
 
 	ts := time.Now()
-	nC := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", ts)
+	nC := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", ts, "")
 
 	c, err := m.GetByProjectAndHash(p, nC.Hash)
 	s.Nil(err)
@@ -105,8 +105,8 @@ func (s *CommitSuite) TestGetAllForProject() {
 
 	b := s.branchManager.Create(p, "testBranch")
 
-	c1 := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", time.Now())
-	c2 := m.Create(b, p, "123456", "2est commit", "me@velocityci.io", time.Now().Add(1*time.Second))
+	c1 := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", time.Now(), "")
+	c2 := m.Create(b, p, "123456", "2est commit", "me@velocityci.io", time.Now().Add(1*time.Second), "")
 
 	cs, total := m.GetAllForProject(p, &githistory.CommitQuery{
 		Limit: 5,
@@ -147,9 +147,9 @@ func (s *CommitSuite) TestGetAllForProjectBranchFilter() {
 	b1 := s.branchManager.Create(p, "testBranch1")
 	b2 := s.branchManager.Create(p, "testBranch2")
 
-	m.Create(b1, p, "abcdef", "test commit", "me@velocityci.io", time.Now())
-	c2 := m.Create(b2, p, "123456", "2est commit", "me@velocityci.io", time.Now().Add(1*time.Second))
-	c3 := m.Create(b2, p, "1234567", "2est commit", "me@velocityci.io", time.Now().Add(2*time.Second))
+	m.Create(b1, p, "abcdef", "test commit", "me@velocityci.io", time.Now(), "")
+	c2 := m.Create(b2, p, "123456", "2est commit", "me@velocityci.io", time.Now().Add(1*time.Second), "")
+	c3 := m.Create(b2, p, "1234567", "2est commit", "me@velocityci.io", time.Now().Add(2*time.Second), "")
 
 	cs, total := m.GetAllForProject(p, &githistory.CommitQuery{
 		Limit:    5,
@@ -194,8 +194,8 @@ func (s *CommitSuite) TestGetAllForBranch() {
 
 	ts := time.Now()
 
-	c1 := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", ts)
-	c2 := m.Create(b, p, "123456", "2est commit", "me@velocityci.io", ts)
+	c1 := m.Create(b, p, "abcdef", "test commit", "me@velocityci.io", ts, "")
+	c2 := m.Create(b, p, "123456", "2est commit", "me@velocityci.io", ts, "")
 
 	cs, total := m.GetAllForBranch(b, &domain.PagingQuery{Limit: 5, Page: 1})
 

--- a/backend/pkg/domain/githistory/githistory.go
+++ b/backend/pkg/domain/githistory/githistory.go
@@ -13,6 +13,7 @@ type Commit struct {
 	Author    string           `json:"author"`
 	CreatedAt time.Time        `json:"createdAt"`
 	Message   string           `json:"message"`
+	Signed    string           `json:"signed"`
 }
 
 type CommitQuery struct {

--- a/backend/pkg/domain/task/sync.go
+++ b/backend/pkg/domain/task/sync.go
@@ -59,6 +59,7 @@ func sync(
 				rawCommit.Message,
 				rawCommit.AuthorEmail,
 				rawCommit.AuthorDate,
+				rawCommit.Signed,
 			)
 			logrus.Infof("\tcreated commit %s on %s", c.Hash, b.Name)
 

--- a/backend/pkg/domain/task/task_test.go
+++ b/backend/pkg/domain/task/task_test.go
@@ -65,7 +65,7 @@ func (s *CommitSuite) TestCreate() {
 
 	br := s.branchManager.Create(p, "testProject")
 
-	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(br, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	m := task.NewManager(s.storm, s.projectManager, s.branchManager, s.commitManager)
 	setupStep := velocity.NewSetup()
@@ -86,7 +86,7 @@ func (s *CommitSuite) TestGetByCommitAndSlug() {
 	})
 
 	b := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(b, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(b, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	m := task.NewManager(s.storm, s.projectManager, s.branchManager, s.commitManager)
 	tsk := m.Create(c, &velocity.Task{
@@ -106,7 +106,7 @@ func (s *CommitSuite) TestGetAllForCommit() {
 	})
 
 	b := s.branchManager.Create(p, "testBranch")
-	c := s.commitManager.Create(b, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC())
+	c := s.commitManager.Create(b, p, "abcdef", "test commit", "me@velocityci.io", time.Now().UTC(), "")
 
 	m := task.NewManager(s.storm, s.projectManager, s.branchManager, s.commitManager)
 	tsk1 := m.Create(c, &velocity.Task{

--- a/backend/pkg/velocity/git.go
+++ b/backend/pkg/velocity/git.go
@@ -29,16 +29,6 @@ type GitRepository struct {
 	PrivateKey string `json:"privateKey"`
 }
 
-// TODO:
-// Clone
-// x Clone Depth (1)
-// - SSH authentication with just private key
-// x Recurse submodules (delay support)
-// Sync
-// x Get remote branches
-// x Get commits at HEAD of each branch
-// x Checkout commit by sha
-
 func Clone(
 	r *GitRepository,
 	bare,
@@ -78,7 +68,7 @@ func Clone(
 	if r.Address[:3] == "git" {
 		key, err := ssh.ParseRawPrivateKey([]byte(r.PrivateKey))
 		if err != nil {
-			return nil, err
+			return nil, err.(SSHKeyError)
 		}
 		if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
 			a := agent.NewClient(sshAgent)
@@ -193,7 +183,7 @@ func (r *RawRepository) done() {
 func (r *RawRepository) GetCommitInfo(sha string) *RawCommit {
 	r.init()
 	defer r.done()
-	shCmd := []string{"git", "show", "-s", `--format=%H%n%aI%n%aE%n%aN%n%G?%n%s`, sha}
+	shCmd := []string{"git", "show", "-s", `--format=%H%n%aI%n%aE%n%aN%n%GK%n%s`, sha}
 	c := cmd.NewCmd(shCmd[0], shCmd[1:len(shCmd)]...)
 	s := <-c.Start()
 


### PR DESCRIPTION
Just added a `signed` field to the commit object, This has the key fingerprint that signed the commit, it's far too much effort to validate (as i'd need to store the trusted GPG keys for an email etc.) but it's there if you'd like to expose it :)
